### PR TITLE
Alt keyboard

### DIFF
--- a/RPN-30.xcodeproj/project.pbxproj
+++ b/RPN-30.xcodeproj/project.pbxproj
@@ -327,12 +327,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 7CQ36333N7;
 				INFOPLIST_FILE = "RPN-30/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MARKETING_VERSION = 1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ashok.RPN-30";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.2;
@@ -345,12 +347,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 7CQ36333N7;
 				INFOPLIST_FILE = "RPN-30/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MARKETING_VERSION = 1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ashok.RPN-30";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.2;

--- a/RPN-30/Info.plist
+++ b/RPN-30/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.25</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/RPN-30/InitializeButtons.swift
+++ b/RPN-30/InitializeButtons.swift
@@ -46,12 +46,12 @@ extension Calculator {
         eightButton.digitString = "eight"
         nineButton.digitString = "nine"
         
-        oneButton.operationString = "EE"
+        oneButton.operationString = "x!"
         twoButton.operationString = "√"
         threeButton.operationString = "1/x"
-        fourButton.operationString = "%"
+        fourButton.operationString = "sin x"
         fiveButton.operationString = "% Δ"
-        sixButton.operationString = "% T"
+        sixButton.operationString = "asin x"
         sevenButton.operationString = "e^x"
         eightButton.operationString = "ln x"
         nineButton.operationString = "y^x"
@@ -183,7 +183,7 @@ extension Calculator {
         
         // Code for oneButton Label
         
-        oneFunctionLabel.text = "EE"
+        oneFunctionLabel.text = "x!"
         oneFunctionLabel.textColor = functionTextColor
         oneFunctionLabel.backgroundColor = functionTitleColor
         oneFunctionLabel.font = functionLabelSize
@@ -237,7 +237,7 @@ extension Calculator {
         
         // Code for fourButton Label
         
-        fourFunctionLabel.text = "%"
+        fourFunctionLabel.text = "sin x"
         fourFunctionLabel.textColor = functionTextColor
         fourFunctionLabel.backgroundColor = functionTitleColor
         fourFunctionLabel.font = functionLabelSize
@@ -273,7 +273,7 @@ extension Calculator {
         
         // Code for sixButton Label
         
-        sixFunctionLabel.text = "% T"
+        sixFunctionLabel.text = "asin x"
         sixFunctionLabel.textColor = functionTextColor
         sixFunctionLabel.backgroundColor = functionTitleColor
         sixFunctionLabel.font = functionLabelSize

--- a/RPN-30/InitializeButtons.swift
+++ b/RPN-30/InitializeButtons.swift
@@ -183,7 +183,7 @@ extension Calculator {
         
         // Code for oneButton Label
         
-        oneFunctionLabel.text = "x!"
+        oneFunctionLabel.text = oneButton.operationString
         oneFunctionLabel.textColor = functionTextColor
         oneFunctionLabel.backgroundColor = functionTitleColor
         oneFunctionLabel.font = functionLabelSize
@@ -201,7 +201,7 @@ extension Calculator {
         
         // Code for twoButton Label
         
-        twoFunctionLabel.text = "√"
+        twoFunctionLabel.text = twoButton.operationString
         twoFunctionLabel.textColor = functionTextColor
         twoFunctionLabel.backgroundColor = functionTitleColor
         twoFunctionLabel.font = functionLabelSize
@@ -219,7 +219,7 @@ extension Calculator {
         
         // Code for threeButton Label
         
-        threeFunctionLabel.text = "1/x"
+        threeFunctionLabel.text = threeButton.operationString
         threeFunctionLabel.textColor = functionTextColor
         threeFunctionLabel.backgroundColor = functionTitleColor
         threeFunctionLabel.font = functionLabelSize
@@ -237,7 +237,7 @@ extension Calculator {
         
         // Code for fourButton Label
         
-        fourFunctionLabel.text = "sin x"
+        fourFunctionLabel.text = fourButton.operationString
         fourFunctionLabel.textColor = functionTextColor
         fourFunctionLabel.backgroundColor = functionTitleColor
         fourFunctionLabel.font = functionLabelSize
@@ -255,7 +255,7 @@ extension Calculator {
         
         // Code for fiveButton Label
  
-        fiveFunctionLabel.text = "% Δ"
+        fiveFunctionLabel.text = fiveButton.operationString
         fiveFunctionLabel.textColor = functionTextColor
         fiveFunctionLabel.backgroundColor = functionTitleColor
         fiveFunctionLabel.font = functionLabelSize
@@ -273,7 +273,7 @@ extension Calculator {
         
         // Code for sixButton Label
         
-        sixFunctionLabel.text = "asin x"
+        sixFunctionLabel.text = sixButton.operationString
         sixFunctionLabel.textColor = functionTextColor
         sixFunctionLabel.backgroundColor = functionTitleColor
         sixFunctionLabel.font = functionLabelSize
@@ -291,7 +291,7 @@ extension Calculator {
         
         // Code for sevenButton Label
         
-        sevenFunctionLabel.text = "e^x"
+        sevenFunctionLabel.text = sevenButton.operationString
         sevenFunctionLabel.textColor = functionTextColor
         sevenFunctionLabel.backgroundColor = functionTitleColor
         sevenFunctionLabel.font = functionLabelSize
@@ -309,7 +309,7 @@ extension Calculator {
         
         // Code for eightButton Label
         
-        eightFunctionLabel.text = "ln x"
+        eightFunctionLabel.text = eightButton.operationString
         eightFunctionLabel.textColor = functionTextColor
         eightFunctionLabel.backgroundColor = functionTitleColor
         eightFunctionLabel.font = functionLabelSize
@@ -328,7 +328,7 @@ extension Calculator {
         
         // Code for nineButton Label
         
-        nineFunctionLabel.text = "y^x"
+        nineFunctionLabel.text = nineButton.operationString
         nineFunctionLabel.textColor = functionTextColor
         nineFunctionLabel.backgroundColor = functionTitleColor
         nineFunctionLabel.font = functionLabelSize

--- a/RPN-30/InitializeButtons.swift
+++ b/RPN-30/InitializeButtons.swift
@@ -46,15 +46,16 @@ extension Calculator {
         eightButton.digitString = "eight"
         nineButton.digitString = "nine"
         
-        oneButton.operationString = "x!"
-        twoButton.operationString = "x√y"
-        threeButton.operationString = "1/x"
-        fourButton.operationString = "sin x"
-        fiveButton.operationString = "% Δ"
+        oneButton.operationString = "1/x"
+        //        twoButton.operationString = "% Δ"
+        twoButton.operationString = "EE"
+        threeButton.operationString = "x!"
+        fourButton.operationString = "y^x"
+        fiveButton.operationString = "x√y"
         sixButton.operationString = "asin x"
         sevenButton.operationString = "e^x"
         eightButton.operationString = "ln x"
-        nineButton.operationString = "y^x"
+        nineButton.operationString = "sin x"
         
         zeroFunctionLabel.adjustsFontSizeToFitWidth = true
         decimalFunctionLabel.adjustsFontSizeToFitWidth = true

--- a/RPN-30/InitializeButtons.swift
+++ b/RPN-30/InitializeButtons.swift
@@ -47,7 +47,7 @@ extension Calculator {
         nineButton.digitString = "nine"
         
         oneButton.operationString = "x!"
-        twoButton.operationString = "√"
+        twoButton.operationString = "x√y"
         threeButton.operationString = "1/x"
         fourButton.operationString = "sin x"
         fiveButton.operationString = "% Δ"

--- a/RPN-30/LogicEngine.swift
+++ b/RPN-30/LogicEngine.swift
@@ -44,7 +44,7 @@ extension Calculator {
             
         case "EE":
             xRegisterNew = yRegister * pow(10.0, Double(xRegister))
-        case "√":
+        case "x√y":
             xRegisterNew = pow(yRegister, 1.0 / xRegister)
         case "1/x":
             xRegisterNew = 1 / xRegister

--- a/RPN-30/LogicEngine.swift
+++ b/RPN-30/LogicEngine.swift
@@ -63,6 +63,38 @@ extension Calculator {
             unaryAction = true
         case "y^x":
             xRegisterNew = pow(yRegister, xRegister)
+            
+        // New functions added Friday 10 April 2020
+        case "sin x":
+            xRegisterNew = sin(xRegister)
+            
+        case "asin x":
+            xRegisterNew = asin(xRegister)
+            unaryAction = true
+
+        case "x!":
+            
+            var xRegisterInt: Int = 0
+            
+            if xRegister >= 0.0 && xRegister < Double(Int.max) {
+                xRegisterInt = Int(xRegister.rounded())
+            }
+            
+            if xRegisterInt == 0 {
+                xRegisterNew = 1
+            } else {
+                
+                var a: Double = 1
+                for i in 1...xRegisterInt {
+                    a *= Double(i)
+                }
+                
+                xRegisterNew = a
+                
+            }
+
+            unaryAction = true
+        
         default:
             return
         }

--- a/RPN-30/OutputDisplay.swift
+++ b/RPN-30/OutputDisplay.swift
@@ -126,9 +126,11 @@ extension Calculator {
         
         if isUnary {
             lRegisterDisplay.text = lOperatorString + "  " + lRegisterXString
+        } else if lOperatorString == "√" {
+            lRegisterDisplay.text = lRegisterXString + "  " + "√" + "  " + lRegisterYString
         } else {
-            lRegisterDisplay.text = lRegisterYString + "  " + lOperatorString + "  " + lRegisterXString
-        }
+	    lRegisterDisplay.text = lRegisterYString + "  " + lOperatorString + "  " + lRegisterXString
+	}
         
     }
     

--- a/RPN-30/OutputDisplay.swift
+++ b/RPN-30/OutputDisplay.swift
@@ -105,7 +105,7 @@ extension Calculator {
         
         let lRegisterX = defaults.double(forKey: "lRegisterX")
         let lRegisterY = defaults.double(forKey: "lRegisterY")
-        let lOperatorString = defaults.string(forKey: "lOperator") ?? ""
+        var lOperatorString = defaults.string(forKey: "lOperator") ?? ""
 
         let lRegisterXNS = NSNumber(value: lRegisterX)
         let lRegisterYNS = NSNumber(value: lRegisterY)
@@ -124,13 +124,41 @@ extension Calculator {
             lRegisterXString = formatterDecimal.string(from: lRegisterXNS) ?? ""
         }
         
-        if isUnary {
-            lRegisterDisplay.text = lOperatorString + "  " + lRegisterXString
-        } else if lOperatorString == "√" {
-            lRegisterDisplay.text = lRegisterXString + "  " + "√" + "  " + lRegisterYString
-        } else {
-	    lRegisterDisplay.text = lRegisterYString + "  " + lOperatorString + "  " + lRegisterXString
-	}
+        switch lOperatorString {
+            
+            case "+":
+                lRegisterDisplay.text = lRegisterYString + " " + lOperatorString + " " + lRegisterXString
+            case "−":
+                lRegisterDisplay.text = lRegisterYString + " " + lOperatorString + " " + lRegisterXString
+            case "x":
+                lRegisterDisplay.text = lRegisterYString + " " + lOperatorString + " " + lRegisterXString
+            case "÷":
+                lRegisterDisplay.text = lRegisterYString + " " + lOperatorString + " " + lRegisterXString
+            case "x!":
+                lRegisterDisplay.text = lRegisterXString + "!"
+            case "x√y":
+                lRegisterDisplay.text = lRegisterXString + " " + "√" + " " + lRegisterYString
+            case "1/x":
+                lRegisterDisplay.text = "1 ÷ " + lRegisterXString
+            case "sin x":
+                lRegisterDisplay.text = "sin(" + lRegisterXString + ")"
+            case "% Δ":
+                lRegisterDisplay.text = "% change  of (" + lRegisterXString + " - " + lRegisterYString + ")"
+            case "asin x":
+                lRegisterDisplay.text = "asin(" + lRegisterXString + ")"
+            case "e^x":
+                lRegisterDisplay.text = "e ^ " + lRegisterXString
+            case "ln x":
+                lRegisterDisplay.text = "ln(" + lRegisterXString + ")"
+            case "y^x":
+                lRegisterDisplay.text = lRegisterYString + " " + "^" + " " + lRegisterXString
+            default:
+                if isUnary {
+                    lRegisterDisplay.text = lOperatorString + "  " + lRegisterXString
+                } else {
+                   lRegisterDisplay.text = lRegisterYString + "  " + lOperatorString + "  " + lRegisterXString
+                }
+        }
         
     }
     


### PR DESCRIPTION
May we please try this alternative keyboard layout? 
It places related functions near each other on the keypad (e^x,ln x) ,(sin x, asin x), (y^x,x rad y).

It also tries EE instead of %D, which I know you prefer. 
Here's my rationale for EE: 
- %D can be achieved with  "final, ENTER, initial, DIV, 1, -" which replaces "initial, ENTER, final, %D". The replacement adds two keystrokes, which is bad.  But "final, ENTER, initial, DIV" is itself often the term of interest because it is the factor by which initial has increased to final.
- EE is valuable because it's easy to make powers of ten mistakes and they are serious.  Many people work in scientific notation all the time.

So that's my case for EE.  Can we try it for a short time at least?

Here's an alternative, but it would require more coding to add a symbol to the CHS key:
Make 1/x into the long tap on CHS.  The logic here is that CHS is the additive inverse and 1/x is the multiplicative inverse.  That would free up one of the number keys, making room for the calculator to have %D and EE.