### PR TITLE
Bug fix: sin stack. Marked sin x as unaryAction

### DIFF
--- a/RPN-30/LogicEngine.swift
+++ b/RPN-30/LogicEngine.swift
@@ -67,6 +67,7 @@ extension Calculator {
         // New functions added Friday 10 April 2020
         case "sin x":
             xRegisterNew = sin(xRegister)
+            unaryAction = true
             
         case "asin x":
             xRegisterNew = asin(xRegister)


### PR DESCRIPTION
Fixed a minor bug. Case "sin x" was not marked as a unary action but needs to be for the stack to function properly. 