### PR TITLE
Added the page of trig functions accessed with TRIG. Rearranged keypad

### DIFF
--- a/RPN-30/InitializeButtons.swift
+++ b/RPN-30/InitializeButtons.swift
@@ -46,14 +46,14 @@ extension Calculator {
         eightButton.digitString = "eight"
         nineButton.digitString = "nine"
         
-        oneButton.operationString = "y^x"
-        twoButton.operationString = "√x"
-        threeButton.operationString = "1/x"
-        fourButton.operationString = "sin x"
-        fiveButton.operationString = "asin x"
-        sixButton.operationString = "x!"
-        sevenButton.operationString = "e^x"
-        eightButton.operationString = "ln x"
+        oneButton.operationString = "√x"
+        twoButton.operationString = "1/x"
+        threeButton.operationString = "y^x"
+        fourButton.operationString = "TRIG"
+        fiveButton.operationString = "ln x"
+        sixButton.operationString = "log10 x"
+        sevenButton.operationString = "x!"
+        eightButton.operationString = "e^x"
         nineButton.operationString = "y EE x"
         
         zeroFunctionLabel.adjustsFontSizeToFitWidth = true

--- a/RPN-30/LogicEngine.swift
+++ b/RPN-30/LogicEngine.swift
@@ -87,24 +87,24 @@ extension Calculator {
             // Treat these unary actions as if they were not so that they roll the stack 
         case "TRIG":
             switch xRegister {
-            case "1":
+            case 1.0:
                 xRegisterNew = sin(yRegister)
-            case "2":
+            case 2.0:
                 xRegisterNew = cos(yRegister)
-            case "3":
+            case 3.0:
                 xRegisterNew = tan(yRegister)
-            case "4":
+            case 4.0:
                 xRegisterNew = asin(yRegister)
-            case "5":
+            case 5.0:
                 xRegisterNew = acos(yRegister)
-            case "6":
+            case 6.0:
                 xRegisterNew = atan(yRegister)
-            case "7":
+            case 7.0:
                 xRegisterNew = Double.pi
                 unaryAction = true
-            case "8":
+            case 8.0:
                 xRegisterNew = Double.pi * yRegister / 180.0
-            case "9":
+            case 9.0:
                 xRegisterNew = 180.0 * yRegister / Double.pi
             default:
                 return

--- a/RPN-30/LogicEngine.swift
+++ b/RPN-30/LogicEngine.swift
@@ -10,6 +10,10 @@ import UIKit
 
 extension Calculator {
     
+    func logC(val: Double, forBase base: Double) -> Double {
+        return log(val)/log(base)
+    }
+    
     // MARK: Operations and Number Entry
     
     func processOperation(_ operation: String){
@@ -73,10 +77,10 @@ extension Calculator {
             xRegisterNew = tgamma(xRegister + 1)
             unaryAction = true
         case "log10 x":
-            xRegisterNew = log10(x)
+            xRegisterNew = logC(val:xRegister, forBase:10.0)
             unaryAction = true
-        case "log2 x":
-            xRegisterNew = log2(x)
+        case "log x":
+            xRegisterNew = logC(val:xRegister, forBase:2.0)
             unaryAction = true
 
             // Trig functions (from second page)
@@ -96,12 +100,12 @@ extension Calculator {
             case "6":
                 xRegisterNew = atan(yRegister)
             case "7":
-                xRegisterNew = M_PI
+                xRegisterNew = Double.pi
                 unaryAction = true
             case "8":
-                xRegisterNew = M_PI * yRegister / 180.0
+                xRegisterNew = Double.pi * yRegister / 180.0
             case "9":
-                xRegisterNew = 180.0 * yRegister / M_PI
+                xRegisterNew = 180.0 * yRegister / Double.pi
             default:
                 return
             }
@@ -125,13 +129,13 @@ extension Calculator {
             xRegisterNew = atan(yRegister)
             unaryAction = true
         case "pi":
-            xRegisterNew = M_PI
+            xRegisterNew = Double.pi
             unaryAction = true
         case "D→R":
-            xRegisterNew = M_PI * yRegister / 180.0
+            xRegisterNew = Double.pi * yRegister / 180.0
             unaryAction = true
         case "R→D":
-            xRegisterNew = 180.0 * yRegister / M_PI
+            xRegisterNew = 180.0 * yRegister / Double.pi
             unaryAction = true
         default:
             return

--- a/RPN-30/LogicEngine.swift
+++ b/RPN-30/LogicEngine.swift
@@ -79,36 +79,29 @@ extension Calculator {
             xRegisterNew = log2(x)
             unaryAction = true
 
-            // Trig functions (from second page)            
+            // Trig functions (from second page)
+            // Treat these unary actions as if they were not so that they roll the stack 
         case "TRIG":
             switch xRegister {
             case "1":
                 xRegisterNew = sin(yRegister)
-                unaryAction = true
             case "2":
                 xRegisterNew = cos(yRegister)
-                unaryAction = true
             case "3":
                 xRegisterNew = tan(yRegister)
-                unaryAction = true
             case "4":
                 xRegisterNew = asin(yRegister)
-                unaryAction = true
             case "5":
                 xRegisterNew = acos(yRegister)
-                unaryAction = true
             case "6":
                 xRegisterNew = atan(yRegister)
-                unaryAction = true
             case "7":
                 xRegisterNew = M_PI
                 unaryAction = true
             case "8":
                 xRegisterNew = M_PI * yRegister / 180.0
-                unaryAction = true
             case "9":
                 xRegisterNew = 180.0 * yRegister / M_PI
-                unaryAction = true
             default:
                 return
             }

--- a/RPN-30/LogicEngine.swift
+++ b/RPN-30/LogicEngine.swift
@@ -11,7 +11,7 @@ import UIKit
 extension Calculator {
     
     // MARK: Operations and Number Entry
-
+    
     func processOperation(_ operation: String){
         
         // Function is called whenever a operator key is entered
@@ -67,53 +67,79 @@ extension Calculator {
         case "y^x":
             xRegisterNew = pow(yRegister, xRegister)
             
-        // New functions added since Friday 10 April 2020
-        case "sin x":
-            xRegisterNew = sin(xRegister)
-            unaryAction = true
-        case "cos x":
-            xRegisterNew = cos(xRegister)
-            unaryAction = true
-        case "tan x":
-            xRegisterNew = tan(xRegister)
-            unaryAction = true
-        case "asin x":
-            xRegisterNew = asin(xRegister)
-            unaryAction = true
-        case "acos x":
-            xRegisterNew = acos(xRegister)
-            unaryAction = true
-        case "atan x":
-            xRegisterNew = atan(xRegister)
-            unaryAction = true
+            // New functions added since Friday 10 April 2020
+            
         case "x!":
             xRegisterNew = tgamma(xRegister + 1)
             unaryAction = true
-            
- /* Old code for integer factorials
-             var xRegisterInt: Int = 0
-             
-             if xRegister >= 0.0 && xRegister < Double(Int.max) {
-                 xRegisterInt = Int(xRegister.rounded())
-             }
-             
-             if xRegisterInt == 0 {
-                 xRegisterNew = 1
-             } else {
-                 
-                 var a: Double = 1
-                 for i in 1...xRegisterInt {
-                     a *= Double(i)
-                 }
-                 
-                 xRegisterNew = a
-                 
-             }
-             
-             
-*/
+        case "log10 x":
+            xRegisterNew = log10(x)
+            unaryAction = true
+        case "log2 x":
+            xRegisterNew = log2(x)
+            unaryAction = true
 
-        
+            // Trig functions (from second page)            
+        case "TRIG":
+            switch xRegister {
+            case "1":
+                xRegisterNew = sin(yRegister)
+                unaryAction = true
+            case "2":
+                xRegisterNew = cos(yRegister)
+                unaryAction = true
+            case "3":
+                xRegisterNew = tan(yRegister)
+                unaryAction = true
+            case "4":
+                xRegisterNew = asin(yRegister)
+                unaryAction = true
+            case "5":
+                xRegisterNew = acos(yRegister)
+                unaryAction = true
+            case "6":
+                xRegisterNew = atan(yRegister)
+                unaryAction = true
+            case "7":
+                xRegisterNew = M_PI
+                unaryAction = true
+            case "8":
+                xRegisterNew = M_PI * yRegister / 180.0
+                unaryAction = true
+            case "9":
+                xRegisterNew = 180.0 * yRegister / M_PI
+                unaryAction = true
+            default:
+                return
+            }
+
+        case "sin x":
+            xRegisterNew = sin(yRegister)
+            unaryAction = true
+        case "cos x":
+            xRegisterNew = cos(yRegister)
+            unaryAction = true
+        case "tan x":
+            xRegisterNew = tan(yRegister)
+            unaryAction = true
+        case "asin x":
+            xRegisterNew = asin(yRegister)
+            unaryAction = true
+        case "acos x":
+            xRegisterNew = acos(yRegister)
+            unaryAction = true
+        case "atan x":
+            xRegisterNew = atan(yRegister)
+            unaryAction = true
+        case "pi":
+            xRegisterNew = M_PI
+            unaryAction = true
+        case "D→R":
+            xRegisterNew = M_PI * yRegister / 180.0
+            unaryAction = true
+        case "R→D":
+            xRegisterNew = 180.0 * yRegister / M_PI
+            unaryAction = true
         default:
             return
         }

--- a/RPN-30/OutputDisplay.swift
+++ b/RPN-30/OutputDisplay.swift
@@ -148,8 +148,10 @@ extension Calculator {
                 lRegisterDisplay.text = "e ^ " + lRegisterXString
             case "ln x":
                 lRegisterDisplay.text = "ln(" + lRegisterXString + ")"
-            case "log10 x"                
-            lRegisterDisplay.text = "log10(" + lRegisterXString + ")"
+            case "log10 x":
+                lRegisterDisplay.text = "log10(" + lRegisterXString + ")"
+            case "log2 x":
+                lRegisterDisplay.text = "log2(" + lRegisterXString + ")"
             case "y^x":
                 lRegisterDisplay.text = lRegisterYString + " " + "^" + " " + lRegisterXString
             case "TRIG":

--- a/RPN-30/OutputDisplay.swift
+++ b/RPN-30/OutputDisplay.swift
@@ -142,18 +142,52 @@ extension Calculator {
                 lRegisterDisplay.text = lRegisterXString + " " + "√" + " " + lRegisterYString
             case "1/x":
                 lRegisterDisplay.text = "1 ÷ " + lRegisterXString
-            case "sin x":
-                lRegisterDisplay.text = "sin(" + lRegisterXString + ")"
             case "% Δ":
                 lRegisterDisplay.text = "% change  of (" + lRegisterXString + " - " + lRegisterYString + ")"
-            case "asin x":
-                lRegisterDisplay.text = "asin(" + lRegisterXString + ")"
             case "e^x":
                 lRegisterDisplay.text = "e ^ " + lRegisterXString
             case "ln x":
                 lRegisterDisplay.text = "ln(" + lRegisterXString + ")"
+            case "log10 x"                
+            lRegisterDisplay.text = "log10(" + lRegisterXString + ")"
             case "y^x":
                 lRegisterDisplay.text = lRegisterYString + " " + "^" + " " + lRegisterXString
+            case "TRIG":
+                switch lRegisterXString {
+                case "1":
+                    lRegisterDisplay.text = "sin(" + lRegisterYString + ")"
+                case "2":
+                    lRegisterDisplay.text = "cos(" + lRegisterYString + ")"
+                case "3":
+                    lRegisterDisplay.text = "tan(" + lRegisterYString + ")"
+                case "4":
+                    lRegisterDisplay.text = "asin(" + lRegisterYString + ")"
+                case "5":
+                    lRegisterDisplay.text = "acos(" + lRegisterYString + ")"
+                case "6":
+                    lRegisterDisplay.text = "atan(" + lRegisterYString + ")"                    
+                case "7":
+                    lRegisterDisplay.text = "pi"
+                case "8":
+                    lRegisterDisplay.text = "D→R"
+                case "9":
+                    lRegisterDisplay.text = "R→D"
+                default:
+                    return
+                }
+                
+            case "sin x":
+                lRegisterDisplay.text = "sin(" + lRegisterYString + ")"
+            case "cos x":
+                lRegisterDisplay.text = "cos(" + lRegisterYString + ")"
+            case "tan x":
+                lRegisterDisplay.text = "tan(" + lRegisterYString + ")"
+            case "asin x":
+                lRegisterDisplay.text = "asin(" + lRegisterYString + ")"
+            case "acos x":
+                lRegisterDisplay.text = "acos(" + lRegisterYString + ")"
+            case "atan x":
+                lRegisterDisplay.text = "atan(" + lRegisterYString + ")"
             default:
                 if isUnary {
                     lRegisterDisplay.text = lOperatorString + "  " + lRegisterXString


### PR DESCRIPTION
I took advantage of the fact that all the trig functions are actually unary to write a very simple ADV.FN interface (which I called TRIG) that should get the stack adjustment right (by not flagging the trig functions as unary). Because the trig functions are unary, it is possible to avoid managing the t register.  Please let me know if this works. 

I also rearranged the keypad more. 